### PR TITLE
注文確定ボタンの二重クリック防止

### DIFF
--- a/src/components/organisms/Confirm/index.tsx
+++ b/src/components/organisms/Confirm/index.tsx
@@ -9,7 +9,7 @@ const Wrapper = styled.div({
 
 export const Confirm: React.FC = () => {
   const { paymentType, customer, onClickConfirmButton } = useConfirm();
-  const [processing, setProcessing] = useState(false);
+  const [disabled, setDisabled] = useState(false);
 
   return (
     <Wrapper>
@@ -30,9 +30,9 @@ export const Confirm: React.FC = () => {
       決済方法: {paymentType}
       <br />
       <button
-        disabled={processing}
+        disabled={disabled}
         onClick={async () => {
-          setProcessing(true);
+          setDisabled(true);
           await onClickConfirmButton();
         }}
       >

--- a/src/components/organisms/Confirm/index.tsx
+++ b/src/components/organisms/Confirm/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { useConfirm } from '../../../store/organisms/Confirm';
 import { CartTable } from '../CartTable';
+import { useState } from 'react';
 
 const Wrapper = styled.div({
   textAlign: 'center',
@@ -8,6 +9,7 @@ const Wrapper = styled.div({
 
 export const Confirm: React.FC = () => {
   const { paymentType, customer, onClickConfirmButton } = useConfirm();
+  const [processing, setProcessing] = useState(false);
 
   return (
     <Wrapper>
@@ -27,7 +29,15 @@ export const Confirm: React.FC = () => {
       <br />
       決済方法: {paymentType}
       <br />
-      <button onClick={onClickConfirmButton}>注文確定</button>
+      <button
+        disabled={processing}
+        onClick={async () => {
+          setProcessing(true);
+          await onClickConfirmButton();
+        }}
+      >
+        注文確定
+      </button>
     </Wrapper>
   );
 };


### PR DESCRIPTION
二重クリック防止のために確定ボタンを押したら画面遷移までdisableにする処理を追加しました。