### PR TITLE
注文完了ページが表示されてからカートの中身を空にする

### DIFF
--- a/src/components/organisms/Complete/index.tsx
+++ b/src/components/organisms/Complete/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { BasicLink } from '~/components/atoms/BasicLink';
 import { routing } from '~/constants/routing';
 import { Box, BoxProps } from '~/lib/styled';
+import { useComplete } from '~/store/organisms/Complete';
 
 interface Props extends BoxProps {
   style?: React.CSSProperties;
@@ -13,6 +14,7 @@ const Wrapper = styled(Box)({
 });
 
 export const Complete: React.FC<Props> = ({ style, ...props }) => {
+  useComplete();
   return (
     <Wrapper style={style} mt={props.mt} mb={props.mb}>
       <h1>ご注文ありがとうございました</h1>

--- a/src/store/organisms/Complete/index.ts
+++ b/src/store/organisms/Complete/index.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { GlobalStore } from '~/store/Global';
+export const useComplete = () => {
+  const { cart: cartStore } = GlobalStore.useContainer();
+  const { clearCart } = cartStore;
+  useEffect(() => {
+    clearCart();
+  }, [clearCart]);
+
+  return {};
+};


### PR DESCRIPTION
完了画面に遷移する前にカートが空になっていたので一瞬合計金額が0と表示される不具合の修正