### PR TITLE
注文フローの改善

### DIFF
--- a/src/components/organisms/Cart/index.tsx
+++ b/src/components/organisms/Cart/index.tsx
@@ -6,6 +6,7 @@ import { SectionTitle } from '~/components/atoms/SectionTitle';
 import { CartTable } from '~/components/molecules/CartTable';
 import { routing } from '~/constants/routing';
 import { Box, BoxProps } from '~/lib/styled';
+import { GlobalStore } from '~/store/Global';
 
 interface Props extends BoxProps {
   style?: React.CSSProperties;
@@ -16,6 +17,7 @@ const Wrapper = styled(Box)({
 });
 
 export const Cart: React.FC<Props> = ({ style, ...props }) => {
+  const { carts } = GlobalStore.useContainer().cart;
   return (
     <Wrapper style={style} mt={props.mt} mb={props.mb}>
       <Box mt={10}>
@@ -26,7 +28,7 @@ export const Cart: React.FC<Props> = ({ style, ...props }) => {
           <CartTable editable showTotal />
           <Box mt={20}>
             <Link href={routing.checkout.root} passHref>
-              <NextButton>注文に進む</NextButton>
+              <NextButton disabled={carts.length === 0}>注文に進む</NextButton>
             </Link>
           </Box>
         </Box>

--- a/src/components/organisms/CheckoutError/index.tsx
+++ b/src/components/organisms/CheckoutError/index.tsx
@@ -1,0 +1,36 @@
+import styled from '@emotion/styled';
+import React from 'react';
+import { BasicLink } from '~/components/atoms/BasicLink';
+import { routing } from '~/constants/routing';
+import { Box, BoxProps } from '~/lib/styled';
+
+interface Props extends BoxProps {
+  style?: React.CSSProperties;
+}
+
+const Wrapper = styled(Box)({
+  textAlign: 'center',
+});
+
+const RedText = styled(Box)({
+  color: 'red',
+});
+
+export const CheckoutError: React.FC<Props> = ({ style, ...props }) => {
+  return (
+    <Wrapper style={style} mt={props.mt} mb={props.mb}>
+      <h1>注文エラーが発生しました</h1>
+      <RedText>注文手続きは行われませんでした。</RedText>
+      <Box mt={30}>以下の原因が考えられます。</Box>
+      <Box mt={30}>ブラウザのリロードなどによりお客様の住所情報が消えてしまった。</Box>
+      <Box>通信エラーにより注文を送信できなかった。</Box>
+      <Box mt={20}>もう一度カートの中身を確認し、再度住所入力をお願いします。</Box>
+      <Box mt={20}>
+        <BasicLink path={routing.root} text={'ホームへ戻る'}></BasicLink>
+      </Box>
+      <Box>
+        <BasicLink path={routing.cart.root} text={'カートへ戻る'}></BasicLink>
+      </Box>
+    </Wrapper>
+  );
+};

--- a/src/constants/init/index.ts
+++ b/src/constants/init/index.ts
@@ -1,12 +1,12 @@
 import { Order } from '~/@types/order';
 
 export const initialOrder: Order = {
-  postalCode: '',
-  address: '',
-  firstName: '',
-  lastName: '',
-  phone: '',
-  email: '',
-  area: 'shizuoka',
-  paymentType: 'postal',
+  postalCode: null,
+  address: null,
+  firstName: null,
+  lastName: null,
+  phone: null,
+  email: null,
+  area: null,
+  paymentType: null,
 };

--- a/src/pages/checkout/error/index.tsx
+++ b/src/pages/checkout/error/index.tsx
@@ -1,0 +1,7 @@
+import { CheckoutError } from '~/components/organisms/CheckoutError';
+
+const Component: React.FC = () => {
+  return <CheckoutError mb={50} />;
+};
+
+export default Component;

--- a/src/store/organisms/Checkout/index.ts
+++ b/src/store/organisms/Checkout/index.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { Order } from '~/@types/order';
 import { routing } from '~/constants/routing';
@@ -26,6 +26,17 @@ export const useCheckout = () => {
     },
     [router, setOrder],
   );
+
+  const beforeUnloadhandler = (event) => {
+    event.returnValue = '入力した内容がリセットされます。よろしいですか？';
+  };
+
+  useEffect(() => {
+    window.addEventListener('beforeunload', beforeUnloadhandler);
+    return () => {
+      window.removeEventListener('beforeunload', beforeUnloadhandler);
+    };
+  }, []);
 
   return { onSubmit, register, handleSubmit, errors };
 };


### PR DESCRIPTION
- 住所入力画面でリロードを押したときにアラートを表示
- 注文確認画面でリロードを押したときにアラートを表示
- カートがからのときカート画面から注文に進めないように（注文進むボタンをsisableに）
- （リロードなどで）住所が消えた状態で注文確定ボタンが押されたらエラー画面に遷移