### PR TITLE
feature: next-seoの導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "export": "next export",
     "start": "next start",
     "lint": "eslint --max-warnings=0 '**/*.tsx' '**/*.ts'"
-
   },
   "dependencies": {
     "@emotion/react": "^11.1.5",
@@ -23,6 +22,7 @@
     "dotenv-expand": "^5.1.0",
     "fs-extra": "^9.0.1",
     "next": "^12.0.1",
+    "next-seo": "^4.28.1",
     "react": "^17.0.2",
     "react-app-polyfill": "^2.0.0",
     "react-dev-utils": "^11.0.3",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,30 @@
 import { AppProps } from 'next/dist/shared/lib/router/router';
 import { GlobalStore } from '~/store/Global';
+import { DefaultSeo } from 'next-seo';
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <GlobalStore.Provider>
+      <DefaultSeo
+        defaultTitle="栗崎園"
+        canonical="https://kurisaki-en.com/"
+        description="お茶農家 栗崎園のホームページ"
+        openGraph={{
+          type: 'website',
+          title: '栗崎園',
+          description: 'お茶農家 栗崎園のホームページ',
+          site_name: '栗崎園',
+          url: 'https://kurisaki-en.com',
+          images: [
+            {
+              url: '/image/main/home.JPG',
+              width: 800,
+              height: 600,
+              alt: '栗崎園',
+            },
+          ],
+        }}
+      />
       <Component {...pageProps} />
     </GlobalStore.Provider>
   );


### PR DESCRIPTION
NEXT-SEOを導入 (https://github.com/garmeeh/next-seo)
defaultSeoを_app.tsxに書くことですべてのページに適用可能(ページごとに設定もできるが、一旦スキップ)
titleなどの基本的な設定とSNSでシェアされたときのためにOpenGraphの設定